### PR TITLE
feat(#70) Clipboard

### DIFF
--- a/src/components/ClipboardDialog.vue
+++ b/src/components/ClipboardDialog.vue
@@ -1,0 +1,329 @@
+<template>
+<Transition name="fade">
+<div v-if="isVisible" class="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
+  <div class="bg-[var(--solid-block-color)] rounded-lg shadow-xl max-w-2xl w-full mx-4 min-h-[280px] overflow-hidden" @click.stop>
+    <!-- Header -->
+    <div class="flex items-center justify-between p-5 border-b border-[var(--split-color)]">
+      <div class="flex items-center">
+        <i :class="[$fa.weight, 'fa-clipboard-list text-lg']" style="color: var(--primary-color)"></i>
+        <span class="ml-3 font-semibold text-lg text-[var(--content-color)]">{{ t('settings.clipboard.dialog.title') }}</span>
+      </div>
+      <button 
+        @click="close"
+        class="p-2 rounded-full hover:bg-[var(--button-color)] transition-colors text-[var(--content-color)]"
+        :title="t('settings.clipboard.dialog.cancel')"
+      >
+        <i class="fa-solid fa-times"></i>
+      </button>
+    </div>
+
+    <!-- Content -->
+    <div v-if="clipboardInfo" class="p-4">
+      <p class="text-sm text-[var(--desc-color)] mb-4 text-center">
+        {{ t('settings.clipboard.dialog.detected') }}
+      </p>
+      
+      <!-- Media Info  -->
+       <div class="flex w-full min-h-36 h-36 bg-[color:var(--block-color)] rounded-lg p-4 gap-4 text-[color:var(--content-color)]">
+        <img 
+          v-if="cover"
+          :src="cover" 
+          :alt="getTitle()"
+          class="object-cover rounded-lg"
+        />
+        <div 
+          v-else
+          class="w-32 h-28 bg-[var(--button-color)] rounded-lg flex items-center justify-center"
+        >
+          <i :class="[$fa.weight, 'fa-image text-2xl']" style="color: var(--desc-color)"></i>
+        </div>
+        
+                 <div class="text flex flex-col flex-1 min-w-0">
+           <h2 class="text-lg ellipsis">{{ getTitle() }}</h2>
+          
+          <!-- Statistics -->
+          <div v-if="hasStats()" class="text-xs flex flex-wrap gap-3 mt-1.5 text-[var(--desc-color)]">
+            <div v-if="getStat('play')" class="flex flex-nowrap gap-1">
+              <i class="bcc-iconfont bcc-icon-icon_list_player_x1"></i>
+              {{ getStat('play') }}
+            </div>
+            <div v-if="getStat('danmaku')" class="flex flex-nowrap gap-1">
+              <i class="bcc-iconfont bcc-icon-danmuguanli"></i>
+              {{ getStat('danmaku') }}
+            </div>
+            <div v-if="getStat('reply')" class="flex flex-nowrap gap-1">
+              <i class="bcc-iconfont bcc-icon-pinglunguanli"></i>
+              {{ getStat('reply') }}
+            </div>
+            <div v-if="getStat('like')" class="flex flex-nowrap gap-1">
+              <i class="bcc-iconfont bcc-icon-ic_Likesx"></i>
+              {{ getStat('like') }}
+            </div>
+            <div v-if="getStat('coin')" class="flex flex-nowrap gap-1">
+              <i class="bcc-iconfont bcc-icon-icon_action_reward_n_x"></i>
+              {{ getStat('coin') }}
+            </div>
+            <div v-if="getStat('favorite')" class="flex flex-nowrap gap-1">
+              <i class="bcc-iconfont bcc-icon-icon_action_collection_n_x"></i>
+              {{ getStat('favorite') }}
+            </div>
+            <div v-if="getStat('share')" class="flex flex-nowrap gap-1">
+              <i class="bcc-iconfont bcc-icon-icon_action_share_n_x"></i>
+              {{ getStat('share') }}
+            </div>
+          </div>
+          
+          <!-- Media type indicator -->
+          <div v-else class="text-xs flex gap-2 mt-1.5 text-[var(--desc-color)]">
+            <div class="flex flex-nowrap gap-1">
+              <i :class="[$fa.weight, getMediaTypeIcon()]"></i>
+              {{ t('mediaType.' + clipboardInfo.mediaInfo.type) }}
+            </div>
+          </div>
+          
+                     <!-- Description or URL -->
+           <span v-if="getDescription()" class="text-sm line-clamp-3 mt-1.5 ellipsis">{{ getDescription() }}</span>
+           <span v-else class="text-xs text-[var(--desc-color)] mt-1.5 break-all line-clamp-2">{{ clipboardInfo.originalUrl }}</span>
+        </div>
+        
+        <!-- User info -->
+        <div v-if="getUploader()" class="flex flex-col items-center cursor-pointer">
+          <img 
+            v-if="avatar"
+            :src="avatar" 
+            class="w-9 rounded-full"
+          />
+          <div 
+            v-else
+            class="w-9 h-9 bg-[var(--button-color)] rounded-full flex items-center justify-center"
+          >
+            <i :class="[$fa.weight, 'fa-user text-sm']" style="color: var(--desc-color)"></i>
+          </div>
+                     <span class="text-xs ellipsis max-w-16 mt-1">{{ getUploader()?.name || 'UP主' }}</span>
+        </div>
+      </div>
+
+      <!-- Actions -->
+      <div class="flex gap-3 mt-4">
+        <button 
+          @click="handleSearch"
+          class="flex-1 px-6 py-3 bg-[var(--primary-color)] text-white rounded-lg hover:brightness-110 transition-all flex items-center justify-center gap-2 font-medium"
+        >
+          <i :class="[$fa.weight, 'fa-search']"></i>
+          <span>{{ t('settings.clipboard.dialog.search') }}</span>
+        </button>
+        <button 
+          @click="close"
+          class="px-6 py-3 bg-[var(--button-color)] text-[var(--content-color)] rounded-lg hover:brightness-110 transition-all flex items-center justify-center gap-2"
+        >
+          <i :class="[$fa.weight, 'fa-times']"></i>
+          <span>{{ t('settings.clipboard.dialog.cancel') }}</span>
+        </button>
+      </div>
+    </div>
+
+    <!-- Loading State -->
+    <div v-else class="p-12 text-center">
+      <div class="animate-spin w-10 h-10 border-3 border-[var(--primary-color)] border-t-transparent rounded-full mx-auto mb-6"></div>
+      <p class="text-[var(--desc-color)] text-lg">{{ t('settings.clipboard.dialog.loading') }}</p>
+      <p class="text-[var(--desc-color)] text-sm mt-2 opacity-75">{{ t('settings.clipboard.dialog.patience') }}</p>
+    </div>
+  </div>
+</div>
+</Transition>
+</template>
+
+<script lang="ts" setup>
+import { ref, inject, watch, onMounted } from 'vue';
+import { useRouter } from 'vue-router';
+import { useI18n } from 'vue-i18n';
+import { getBlob, stat } from '@/services/utils';
+import type { ClipboardDetection } from '@/services/clipboard';
+import type * as Types from '@/types/shared.d';
+
+// Define props
+interface Props {
+  modelValue?: boolean;
+}
+
+// Define emits
+interface Emits {
+  (e: 'update:modelValue', value: boolean): void;
+  (e: 'search', info: ClipboardDetection): void;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  modelValue: false
+});
+
+const emit = defineEmits<Emits>();
+
+// Composables
+const router = useRouter();
+const { t } = useI18n();
+const $fa = inject('$fa', { weight: 'fa-regular', isDark: false });
+
+// Reactive state
+const isVisible = ref(props.modelValue);
+const clipboardInfo = ref<ClipboardDetection | null>(null);
+const cover = ref('');
+const avatar = ref('');
+
+// Watch for prop changes
+watch(() => props.modelValue, (value) => {
+  isVisible.value = value;
+});
+
+// Methods
+function close() {
+  isVisible.value = false;
+  emit('update:modelValue', false);
+  clipboardInfo.value = null;
+  cover.value = '';
+  avatar.value = '';
+}
+
+
+function handleSearch() {
+  if (clipboardInfo.value) {
+    emit('search', clipboardInfo.value);
+    // Navigate to search page
+    router.push('/').then(() => {
+      // The parent component should handle the actual search
+      close();
+    });
+  }
+}
+
+function getTitle(): string {
+  if (!clipboardInfo.value) return '';
+  const mediaInfo = clipboardInfo.value.mediaInfo;
+  return mediaInfo.nfo?.showtitle || mediaInfo.list?.[0]?.title || '';
+}
+
+function getMediaTypeIcon(): string {
+  if (!clipboardInfo.value) return 'fa-video';
+  
+  const iconMap = {
+    'video': 'fa-video',
+    'bangumi': 'fa-tv',
+    'music': 'fa-music',
+    'musicList': 'fa-list-music',
+    'lesson': 'fa-graduation-cap',
+    'favorite': 'fa-heart'
+  };
+  
+  return iconMap[clipboardInfo.value.mediaInfo.type] || 'fa-video';
+}
+
+function getDescription(): string {
+  if (!clipboardInfo.value) return '';
+  return clipboardInfo.value.mediaInfo.desc || '';
+}
+
+function getUploader() {
+  if (!clipboardInfo.value) return null;
+  return clipboardInfo.value.mediaInfo.nfo?.upper;
+}
+
+function hasStats(): boolean {
+  if (!clipboardInfo.value) return false;
+  const stat = clipboardInfo.value.mediaInfo.stat;
+  return !!(stat?.play || stat?.danmaku || stat?.reply || stat?.like || stat?.coin || stat?.favorite || stat?.share);
+}
+
+function getStat(key: keyof Types.MediaInfo['stat']): string {
+  const statValue = clipboardInfo.value?.mediaInfo.stat?.[key];
+  if (!statValue) return '';
+  return stat(statValue as number);
+}
+
+async function loadCover() {
+  if (!clipboardInfo.value?.mediaInfo.nfo?.thumbs?.length) {
+    cover.value = '';
+    return;
+  }
+  
+  try {
+    const thumbUrl = clipboardInfo.value.mediaInfo.nfo.thumbs[0].url;
+    cover.value = await getBlob(thumbUrl);
+    console.log('[ClipboardDialog] Cover loaded successfully');
+  } catch (error) {
+    console.warn('[ClipboardDialog] Failed to load cover:', error);
+    cover.value = '';
+  }
+}
+
+async function loadAvatar() {
+  const uploader = getUploader();
+  if (!uploader?.avatar) {
+    avatar.value = '';
+    return;
+  }
+  
+  try {
+    avatar.value = await getBlob(uploader.avatar + '@64h');
+    console.log('[ClipboardDialog] Avatar loaded successfully');
+  } catch (error) {
+    console.warn('[ClipboardDialog] Failed to load avatar:', error);
+    avatar.value = '';
+  }
+}
+
+// Expose methods
+function show(info: ClipboardDetection) {
+  console.log('[ClipboardDialog] Showing dialog with info:', info);
+  clipboardInfo.value = info;
+  cover.value = ''; // Reset cover
+  avatar.value = ''; // Reset avatar
+  isVisible.value = true;
+  emit('update:modelValue', true);
+  
+  // Load images
+  loadCover();
+  loadAvatar();
+}
+
+defineExpose({
+  show,
+  close
+});
+</script>
+
+<style scoped>
+.line-clamp-2 {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.3s ease;
+}
+
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}
+
+.fade-enter-active .bg-\[var\(--solid-block-color\)\],
+.fade-leave-active .bg-\[var\(--solid-block-color\)\] {
+  transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.fade-enter-from .bg-\[var\(--solid-block-color\)\] {
+  transform: scale(0.95) translateY(10px);
+}
+
+.fade-leave-to .bg-\[var\(--solid-block-color\)\] {
+  transform: scale(0.95) translateY(10px);
+}
+
+/* MediaInfo styles reuse */
+h2 ~ span {
+  @apply whitespace-pre-wrap;
+  display: -webkit-box;
+}
+</style> 

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -134,7 +134,8 @@
         "sidecar": "Sidecar {0} Error",
         "checkUpdate": "Check the latest updates on GitHub",
         "invalidInput": "Failed to parse input",
-        "selectLimit": "It is not recommended to select more than 30 items at once"
+        "selectLimit": "It is not recommended to select more than 30 items at once",
+        "clipboardRead": "Failed to read clipboard content"
     },
     "updater": {
         "title": "New version available!",
@@ -202,7 +203,16 @@
             "auto": "Follow System"
         },
         "clipboard": {
-            "name": "Clipboard Monitor"
+            "name": "Clipboard Monitor",
+            "desc": "If enabled, automatically detects Bilibili links in clipboard and shows a dialog.",
+            "dialog": {
+                "title": "Bilibili Content Detected",
+                "detected": "Detected the following Bilibili content from clipboard",
+                "search": "Search Now",
+                "cancel": "Cancel",
+                "loading": "Getting video information...",
+                "patience": "Please wait, parsing content"
+            }
         },
         "notify": {
             "name": "Notification",

--- a/src/i18n/locales/ja-JP.json
+++ b/src/i18n/locales/ja-JP.json
@@ -134,7 +134,8 @@
         "sidecar": "Sidecar {0} のエラー",
         "checkUpdate": "GitHub で最新バージョンを確認してください",
         "invalidInput": "入力を解析できません",
-        "selectLimit": "一度に 30 個以上選択することは推奨されません"
+        "selectLimit": "一度に 30 個以上選択することは推奨されません",
+        "clipboardRead": "クリップボードの内容を読み取れませんでした"
     },
     "updater": {
         "title": "新しいバージョンが見つかりました！",
@@ -202,7 +203,16 @@
             "auto": "システムに従う"
         },
         "clipboard": {
-            "name": "クリップボード監視"
+            "name": "クリップボード監視",
+            "desc": "有効にすると、クリップボード内のBilibiliリンクを自動検出してダイアログを表示します。",
+            "dialog": {
+                "title": "Bilibiliコンテンツを検出",
+                "detected": "クリップボードから以下のBilibiliコンテンツを検出しました",
+                "search": "今すぐ検索",
+                "cancel": "キャンセル",
+                "loading": "動画情報を取得中...",
+                "patience": "しばらくお待ちください、コンテンツを解析中"
+            }
         },
         "notify": {
             "name": "通知",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -133,7 +133,8 @@
         "risk": "触发风控，请进行验证",
         "checkUpdate": "请在 GitHub 检查最新更新",
         "invalidInput": "无法解析输入",
-        "selectLimit": "不建议一次选择超过 30 个选项"
+        "selectLimit": "不建议一次选择超过 30 个选项",
+        "clipboardRead": "无法读取剪切板内容"
     },
     "updater": {
         "title": "发现新版本！",
@@ -204,7 +205,16 @@
             "auto": "遵循系统"
         },
         "clipboard" :{
-            "name": "监听剪贴板"
+            "name": "监听剪贴板",
+            "desc": "若启用，则会自动检测剪贴板中的B站链接并弹出对话框。",
+            "dialog": {
+                "title": "检测到B站内容",
+                "detected": "从剪贴板中检测到以下B站内容",
+                "search": "立即搜索",
+                "cancel": "取消",
+                "loading": "正在获取视频信息...",
+                "patience": "请稍候，正在解析内容"
+            }
         },
         "notify": {
             "name": "通知系统",

--- a/src/i18n/locales/zh-HK.json
+++ b/src/i18n/locales/zh-HK.json
@@ -134,7 +134,8 @@
         "sidecar": "Sidecar {0} 的錯誤",
         "checkUpdate": "請到 GitHub 檢查最新更新",
         "invalidInput": "無法解析輸入",
-        "selectLimit": "不建議一次選擇超過 30 個選項"
+        "selectLimit": "不建議一次選擇超過 30 個選項",
+        "clipboardRead": "無法讀取剪貼簿內容"
     },
     "updater": {
         "title": "發現新版本！",
@@ -202,7 +203,16 @@
             "auto": "跟隨系統"
         },
         "clipboard": {
-            "name": "監聽剪貼簿"
+            "name": "監聽剪貼簿",
+            "desc": "若啟用，則會自動檢測剪貼簿中的B站連結並彈出對話方塊。",
+            "dialog": {
+                "title": "檢測到B站內容",
+                "detected": "從剪貼簿中檢測到以下B站內容",
+                "search": "立即搜尋",
+                "cancel": "取消",
+                "loading": "正在獲取影片資訊...",
+                "patience": "請稍候，正在解析內容"
+            }
         },
         "notify": {
             "name": "通知系統",

--- a/src/services/clipboard.ts
+++ b/src/services/clipboard.ts
@@ -1,0 +1,189 @@
+import { readText } from '@tauri-apps/plugin-clipboard-manager';
+import { ref, watch } from 'vue';
+import { useSettingsStore } from '@/store';
+import { parseId } from './utils';
+import { data } from './media';
+import * as Types from '@/types/shared.d';
+import { AppError } from './error';
+import i18n from '@/i18n';
+
+export interface ClipboardDetection {
+  originalUrl: string;
+  mediaInfo: Types.MediaInfo;
+}
+
+export class ClipboardService {
+  private isRunning = false;
+  private intervalId: number | null = null;
+  private lastClipboardContent = '';
+  private callbacks: ((info: ClipboardDetection) => void)[] = [];
+  private initialized = false;
+
+  constructor() {
+    // Don't initialize immediately - wait for init() call
+  }
+
+  /**
+   * Initialize the service with store access
+   */
+  init() {
+    if (this.initialized) return;
+    this.initialized = true;
+
+    const settings = useSettingsStore();
+    
+    console.log('[ClipboardService] Initializing with clipboard setting:', settings.clipboard);
+    
+    // Watch clipboard setting changes
+    watch(() => settings.clipboard, (enabled) => {
+      console.log('[ClipboardService] Clipboard setting changed:', enabled);
+      if (enabled) {
+        this.start();
+      } else {
+        this.stop();
+      }
+    }, { immediate: true });
+  }
+
+  /**
+   * Start clipboard monitoring
+   */
+  start() {
+    if (this.isRunning) return;
+    
+    console.log('[ClipboardService] Starting clipboard monitoring');
+    this.isRunning = true;
+    this.intervalId = window.setInterval(async () => {
+      try {
+        await this.checkClipboard();
+      } catch (error) {
+        console.error('[ClipboardService] Clipboard check error:', error);
+      }
+    }, 1000); // Check every second
+  }
+
+  /**
+   * Stop clipboard monitoring
+   */
+  stop() {
+    if (!this.isRunning) return;
+    
+    console.log('[ClipboardService] Stopping clipboard monitoring');
+    this.isRunning = false;
+    if (this.intervalId) {
+      clearInterval(this.intervalId);
+      this.intervalId = null;
+    }
+  }
+
+  /**
+   * Add callback for when Bilibili content is detected
+   */
+  onBilibiliDetected(callback: (info: ClipboardDetection) => void) {
+    this.callbacks.push(callback);
+  }
+
+  /**
+   * Remove callback
+   */
+  removeCallback(callback: (info: ClipboardDetection) => void) {
+    const index = this.callbacks.indexOf(callback);
+    if (index > -1) {
+      this.callbacks.splice(index, 1);
+    }
+  }
+
+  /**
+   * Check clipboard content for changes and Bilibili links
+   */
+  private async checkClipboard() {
+    try {
+      const currentContent = await readText();
+      
+      // Skip if content hasn't changed
+      if (currentContent === this.lastClipboardContent) {
+        return;
+      }
+      
+      console.log('[ClipboardService] New clipboard content detected:', currentContent?.substring(0, 100) + '...');
+      this.lastClipboardContent = currentContent;
+      
+      // Skip empty content
+      if (!currentContent?.trim()) {
+        console.log('[ClipboardService] Skipping empty content');
+        return;
+      }
+
+      // Try to parse as Bilibili content
+      await this.processBilibiliContent(currentContent.trim());
+      
+    } catch (error) {
+      // Log all clipboard errors for debugging
+      console.warn('[ClipboardService] Clipboard read error:', error);
+    }
+  }
+
+  /**
+   * Process potential Bilibili content
+   */
+  private async processBilibiliContent(content: string) {
+    try {
+      console.log('[ClipboardService] Processing content:', content);
+      
+      // Try to parse the content as Bilibili ID/URL
+      const parseResult = await parseId(content, false);
+      console.log('[ClipboardService] Parse result:', parseResult);
+      
+      if (!parseResult.id || !parseResult.type) {
+        console.log('[ClipboardService] Not a valid Bilibili link');
+        return; // Not a valid Bilibili link
+      }
+
+      console.log('[ClipboardService] Getting media info for:', parseResult.id, parseResult.type);
+      
+      // Get media info
+      const mediaInfo = await data.getMediaInfo(parseResult.id, parseResult.type);
+      
+      // Validate media info
+      if (!mediaInfo.nfo?.showtitle && !mediaInfo.list?.[0]?.title) {
+        console.log('[ClipboardService] Failed to get media info');
+        return; // Failed to get media info
+      }
+
+      // Create clipboard detection info
+      const clipboardInfo: ClipboardDetection = {
+        originalUrl: content,
+        mediaInfo: mediaInfo
+      };
+
+      console.log('[ClipboardService] Bilibili content detected:', clipboardInfo);
+
+      // Notify all callbacks
+      this.callbacks.forEach(callback => {
+        try {
+          callback(clipboardInfo);
+        } catch (error) {
+          console.error('[ClipboardService] Callback error:', error);
+        }
+      });
+
+    } catch (error) {
+      // Log parsing errors for debugging
+      console.log('[ClipboardService] Not a Bilibili link or parsing failed:', content, error);
+    }
+  }
+
+  /**
+   * Get current clipboard content
+   */
+  async getCurrentContent(): Promise<string> {
+    try {
+      return await readText();
+    } catch (error) {
+      throw new AppError(i18n.global.t('error.clipboardRead'), { name: 'ClipboardError' });
+    }
+  }
+}
+
+// Export singleton instance (will be initialized later)
+export const clipboardService = new ClipboardService(); 


### PR DESCRIPTION
# 剪切板监听功能实现#70


## 主要变更

- **ClipboardDialog.vue**: 剪切板检测对话框组件
- **clipboard.ts**: 剪切板监听服务

### 设置界面
- **General.vue**: 启用剪切板监听选项
<img width="470" height="81" alt="image" src="https://github.com/user-attachments/assets/e67d69e7-57b2-4b59-ab08-a219a5556e9f" />

### i18n支持
- 新增剪切板相关文本翻译
- 支持中文、英文、日文、繁体中文

## 技术实现

1. 使用 Tauri 的 clipboard-manager 插件读取剪切板
2. 定时轮询检测内容变化（1秒间隔）
3. 解析B站链接并获取媒体信息
4. 通过回调机制触发UI更新
![2025-08-2306-51-58-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/c2786229-89bc-4153-844d-ecf9a09adc68)

