### PR TITLE
feat: add window effect settings option

### DIFF
--- a/src-tauri/src/storage/config.rs
+++ b/src-tauri/src/storage/config.rs
@@ -9,7 +9,7 @@ use specta::Type;
 use sqlx::Row;
 
 use super::db::{get_db, TableSpec};
-use crate::shared::{get_app_handle, Theme, CONFIG};
+use crate::shared::{get_app_handle, Theme, WindowEffect, CONFIG};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Type)]
 #[serde(rename_all = "camelCase")]
@@ -37,6 +37,7 @@ pub struct Settings {
     pub notify: bool,
     pub temp_dir: PathBuf,
     pub theme: Theme,
+    pub window_effect: WindowEffect,
     pub organize: SettingsOrganize,
     pub proxy: SettingsProxy,
 }

--- a/src/components/SettingsPage/General.vue
+++ b/src/components/SettingsPage/General.vue
@@ -21,6 +21,18 @@
         v-model="settings.theme"
     />
 </section>
+<section>
+    <h3>
+        <i class="fa-solid fa-window-maximize"></i>
+        <span>{{ $t('settings.window_effect.name') }}</span>
+    </h3>
+    <Dropdown
+        :drop="['auto', 'mica', 'acrylic', 'sidebar', 'none'].map(id => ({
+            id, name: $t('settings.window_effect.' + id)
+        }))"
+        v-model="settings.window_effect"
+    />
+</section>
 <hr />
 <section>
     <h3>

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -231,6 +231,14 @@
             "dark": "Dark",
             "auto": "Follow System"
         },
+        "window_effect": {
+            "name": "Window Effect",
+            "auto": "Auto",
+            "mica": "Mica",
+            "acrylic": "Acrylic",
+            "sidebar": "Sidebar",
+            "none": "None"
+        },
         "clipboard": {
             "name": "Clipboard Monitor",
             "desc": "If enabled, auto-detect Bilibili links in the clipboard and search."

--- a/src/i18n/locales/ja-JP.json
+++ b/src/i18n/locales/ja-JP.json
@@ -231,6 +231,14 @@
             "dark": "ダーク",
             "auto": "システムに従う"
         },
+        "window_effect": {
+            "name": "ウィンドウ効果",
+            "auto": "自動",
+            "mica": "Mica",
+            "acrylic": "Acrylic",
+            "sidebar": "Sidebar",
+            "none": "効果なし"
+        },
         "clipboard": {
             "name": "クリップボード監視",
             "desc": "有効時、クリップボードの Bilibili リンクを自動検出して検索します。"

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -231,6 +231,14 @@
             "dark": "深色",
             "auto": "遵循系统"
         },
+        "window_effect": {
+            "name": "窗口效果",
+            "auto": "自动",
+            "mica": "Mica",
+            "acrylic": "Acrylic", 
+            "sidebar": "Sidebar",
+            "none": "无"
+        },
         "clipboard": {
             "name": "监听剪贴板",
             "desc": "若启用，则会自动检测剪贴板中的哔哩哔哩链接并搜索。"

--- a/src/i18n/locales/zh-HK.json
+++ b/src/i18n/locales/zh-HK.json
@@ -231,6 +231,14 @@
             "dark": "深色",
             "auto": "跟隨系統"
         },
+        "window_effect": {
+            "name": "視窗效果",
+            "auto": "自動",
+            "mica": "Mica",
+            "acrylic": "Acrylic",
+            "sidebar": "Sidebar",
+            "none": "無"
+        },
         "clipboard": {
             "name": "監聽剪貼簿",
             "desc": "若啟用，則會自動檢測剪貼簿中的嗶哩嗶哩連結並搜尋。"

--- a/src/services/backend.ts
+++ b/src/services/backend.ts
@@ -21,9 +21,9 @@ async init() : Promise<Result<null, TauriError>> {
     else return { status: "error", error: e  as any };
 }
 },
-async setWindow(theme: Theme) : Promise<Result<null, TauriError>> {
+async setWindow(theme: Theme, windowEffect: WindowEffect) : Promise<Result<null, TauriError>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("set_window", { theme }) };
+    return { status: "ok", data: await TAURI_INVOKE("set_window", { theme, windowEffect }) };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
@@ -212,7 +212,7 @@ export type QueueData = { waiting: string[]; doing: string[]; complete: string[]
 export type QueueEvent = { type: "snapshot"; init: boolean; queue: QueueData; tasks?: Partial<{ [key in string]: Task }> | null; schedulers?: Partial<{ [key in string]: SchedulerView }> | null } | { type: "state"; parent: string; state: TaskState } | { type: "progress"; parent: string; id: string; status: SubTaskStatus } | { type: "request"; parent: string; subtask: string | null; action: RequestAction } | { type: "error"; parent: string; id?: string | null; message: string; code: number | null }
 export type RequestAction = "refreshNfo" | "refreshUrls" | "refreshFolder" | "getFilename" | "getNfo" | "getThumbs" | "getDanmaku" | "getSubtitle" | "getAISummary"
 export type SchedulerView = { sid: string; ts: number; list: string[] }
-export type Settings = { add_metadata: boolean; auto_check_update: boolean; auto_download: boolean; block_pcdn: boolean; check_update: boolean; clipboard: boolean; convert: SettingsConvert; default: SettingsDefault; down_dir: string; format: SettingsFormat; language: string; max_conc: number; notify: boolean; temp_dir: string; theme: Theme; organize: SettingsOrganize; proxy: SettingsProxy }
+export type Settings = { add_metadata: boolean; auto_check_update: boolean; auto_download: boolean; block_pcdn: boolean; check_update: boolean; clipboard: boolean; convert: SettingsConvert; default: SettingsDefault; down_dir: string; format: SettingsFormat; language: string; max_conc: number; notify: boolean; temp_dir: string; theme: Theme; window_effect: WindowEffect; organize: SettingsOrganize; proxy: SettingsProxy }
 export type SettingsConvert = { danmaku: boolean; mp3: boolean }
 export type SettingsDefault = { res: number; abr: number; enc: number }
 export type SettingsFormat = { series: string; item: string; file: string }
@@ -240,6 +240,27 @@ export type Theme =
  */
 "auto"
 export type ThemeEvent = { dark: boolean; color: string | null }
+export type WindowEffect = 
+/**
+ * Auto window effect based on platform
+ */
+"auto" | 
+/**
+ * Mica effect (Windows 11+)
+ */
+"mica" | 
+/**
+ * Acrylic effect (Windows 10+)
+ */
+"acrylic" | 
+/**
+ * Sidebar effect (macOS)
+ */
+"sidebar" | 
+/**
+ * No window effect
+ */
+"none"
 
 /** tauri-specta globals **/
 

--- a/src/services/utils.ts
+++ b/src/services/utils.ts
@@ -45,7 +45,7 @@ export function setEventHook() {
     watch(settings.$state, (v) => {
         i18n.global.locale.value = v.language;
         commands.configWrite(v);
-        commands.setWindow(v.theme);
+        commands.setWindow(v.theme, v.window_effect);
         commands.updateMaxConc(v.max_conc);
     }, { deep: true });
     events.headersData.listen(e => app.$patch({

--- a/src/store/settings.ts
+++ b/src/store/settings.ts
@@ -30,6 +30,7 @@ export const useSettingsStore = defineStore('settings', () => {
         notify: true,
         temp_dir: String(),
         theme: 'auto',
+        window_effect: 'auto',
         organize: {
             auto_rename: true,
             top_folder: true,


### PR DESCRIPTION
# 窗口效果设置功能实现


### 后端实现
- **shared.rs**: 新增 WindowEffect 枚举，修改 set_window 函数
- **config.rs**: Settings 结构体添加 window_effect 字段

### 前端实现
- **General.vue**: 在主题设置下方添加窗口效果选择器
- **settings.ts**: 前端设置存储添加 window_effect 字段
- **utils.ts**: setEventHook 支持窗口效果参数
- **backend.ts**: 更新 setWindow 命令接口和类型定义

### 设置界面
- **General.vue**: 新增窗口效果下拉选择器，位于主题设置下方
- 支持五种效果（默认为自动）：自动/Mica (Win11+) /Acrylic (Win10+) /SideBar (Mac) /无
- 补充窗口效果相关文本翻译

![2025-09-0704-17-33-ezgif com-optimize](https://github.com/user-attachments/assets/555b7d17-14b2-49ee-a6e5-c5b9bb76690f)


