### PR TITLE
Feat(MediaInfo): enable scrolling for description

### DIFF
--- a/src/components/SearchPage/MediaInfo.vue
+++ b/src/components/SearchPage/MediaInfo.vue
@@ -9,7 +9,9 @@
             </div>
             </template>
         </div>
-        <span class="text-sm line-clamp-3 mt-1.5 ellipsis">{{ info.desc }}</span>
+        <div class="flex-1 overflow-auto mt-1.5">
+            <span class="text-sm">{{ info.desc }}</span>
+        </div>
     </div>
     <a v-if="props.info.nfo.upper?.avatar"
         @click="openUrl('https://space.bilibili.com/' + info.nfo.upper?.mid)"
@@ -44,8 +46,7 @@ const iconMap = {
 <style scoped>
 @reference 'tailwindcss';
 
-h2 ~ span {
+h2 ~ div span {
     @apply whitespace-pre-wrap;
-    display: -webkit-box;
 }
 </style>


### PR DESCRIPTION
# 简介滚动功能实现

## 主要变更

- **MediaInfo.vue**: 移除简介内容文字行数限制，添加滚动容器支持，移除webkit-box显示限制

## 技术实现

1. **移除行数限制**: 删除 `line-clamp-3` 类，不再限制显示为3行
2. **添加滚动容器**: 使用 `flex-1 overflow-auto` 创建可滚动区域

![2025-09-0823-17-02-ezgif com-crop](https://github.com/user-attachments/assets/a9bd1528-7db4-4f61-9327-0ae7d6d876fa)
