### PR TITLE
Feat(SideBar): add always-on-top toggle

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -18,6 +18,7 @@
     "core:window:allow-is-focused",
     "core:window:allow-unminimize",
     "core:window:allow-start-dragging",
+    "core:window:allow-set-always-on-top",
     "shell:allow-open",
     "opener:allow-open-path",
     "opener:allow-open-url",

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -19,6 +19,7 @@
     "core:window:allow-unminimize",
     "core:window:allow-start-dragging",
     "core:window:allow-set-always-on-top",
+    "core:window:allow-is-always-on-top",
     "shell:allow-open",
     "opener:allow-open-path",
     "opener:allow-open-url",

--- a/src/components/SideBar.vue
+++ b/src/components/SideBar.vue
@@ -18,15 +18,13 @@
 <script setup lang="ts">
 import { computed, inject, Ref } from 'vue';
 import { type as osType } from '@tauri-apps/plugin-os';
-import { getCurrentWindow } from '@tauri-apps/api/window';
-import { useUserStore, useSettingsStore, useAppStore } from "@/store";
+import { useUserStore, useSettingsStore } from "@/store";
 import Updater from './Updater.vue';
 import router from '@/router';
 import Image from './Image.vue';
 
 const user = useUserStore();
 const settings = useSettingsStore();
-const app = useAppStore();
 const os = osType();
 
 const updater = inject<Ref<InstanceType<typeof Updater>>>('updater');
@@ -37,7 +35,6 @@ const list = computed(() => ([
     { path: '/history-page', icon: 'fa-clock' },
     { path: '/down-page', icon: 'fa-download' },
     { path: 'theme', icon: 'fa-solid fa-moon-over-sun' },
-    { path: 'pin', icon: app.isAlwaysOnTop ? 'fa-solid fa-thumbtack' : 'fa-light fa-thumbtack' },
     { path: '/settings-page', icon: 'fa-gear' },
     { path: '/info-page', icon: 'fa-circle-info' },
 ]));
@@ -46,20 +43,8 @@ function setTheme() {
     settings.theme = settings.isDark ? 'light' : 'dark';
 }
 
-async function toggleAlwaysOnTop() {
-    try {
-        const window = getCurrentWindow();
-        const newState = !app.isAlwaysOnTop;
-        await window.setAlwaysOnTop(newState);
-        app.isAlwaysOnTop = newState;
-    } catch (error) {
-        console.error('Failed to toggle always on top:', error);
-    }
-}
-
 async function click(path: string) {
     if (path === 'theme') return setTheme();
-    if (path === 'pin') return toggleAlwaysOnTop();
     if (updater?.value.active) updater.value?.close();
     router.push(path);
 }

--- a/src/components/TitleBar.vue
+++ b/src/components/TitleBar.vue
@@ -3,6 +3,9 @@
 	class="titlebar absolute right-0 h-[30px] w-[calc(100vw-56px)] bg-transparent"
 >
     <div v-if="osType() !== 'macos'" class='relative z-100 float-right'>
+        <div class="button" @click="toggleTop">
+            <i :class="[isTop ? 'fa-solid' : 'fa-light', 'fa-thumbtack']"></i>
+        </div>
         <div class="button translate-y-[-5px]" @click="appWindow.minimize()">
             <div class="h-px!"></div>
         </div>
@@ -25,6 +28,7 @@ import { type as osType } from '@tauri-apps/plugin-os';
 
 const maxed = ref(false);
 const appWindow = getCurrentWindow();
+const isTop = ref(false);
 
 const icons = {
     max: new URL('@/assets/img/titlebar/max.svg', import.meta.url).href,
@@ -32,11 +36,14 @@ const icons = {
     close: new URL('@/assets/img/titlebar/close.svg', import.meta.url).href,
 }
 
-onMounted(() => {
-    appWindow.onResized(debounce(async () => {
-        maxed.value = await appWindow.isMaximized();
-    }, 250));
-})
+async function toggleTop() {
+    await appWindow.setAlwaysOnTop(!isTop.value);
+    isTop.value = await appWindow.isAlwaysOnTop()
+}
+
+onMounted(() => appWindow.onResized(debounce(async () => {
+    maxed.value = await appWindow.isMaximized();
+}, 250)));
 </script>
 
 <style scoped>
@@ -44,10 +51,10 @@ onMounted(() => {
 
 .button {
     @apply inline-flex justify-center items-center transition-all;
-    @apply hover:bg-(--block-color);
+    @apply hover:bg-(--block-color) text-(--content-color) text-xs;
 	width: 45px;
 	height: 29px;
-    & > div {
+    div {
         @apply w-2.5 h-2.5 bg-(--content-color);
         mask-repeat: no-repeat;
         mask-size: cover;

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -6,6 +6,7 @@ export const useAppStore = defineStore('app', {
         version: String(),
         hash: String(),
         inited: false,
+        isAlwaysOnTop: false,
         headers: {} as HeadersData,
         cache: {
             log: Number(),


### PR DESCRIPTION
# 窗口置顶功能实现

## 主要变更

- **SideBar.vue**: 在侧边栏主题切换按钮下方添加置顶按钮，实现窗口置顶切换功能
- **图标**: 置顶时显示实心图标，未置顶时显示线条图标
- **app.ts**: 添加置顶状态管理，跟踪窗口置顶状态
- **default.json**: 添加窗口置顶权限，启用 `setAlwaysOnTop`
调用 Tauri `getCurrentWindow().setAlwaysOnTop()` [API](https://tauri.app/v1/api/js/window#windowsetalwaysontop)

## 技术实现

1. **状态管理**: 在 app store 中添加 `isAlwaysOnTop`
2. **权限配置**: 添加 `core:window:allow-set-always-on-top`

<p align="center">
  <img src="https://github.com/user-attachments/assets/51f7dd7b-dc8d-42b2-8699-ab0c8eaaa34d" width="600px">
</p>



<p align="center">
  <strong>演示</strong>
</p>
