### PR TITLE
feat: add danmaku download option to general download

### DIFF
--- a/src/components/SearchPage/Popup.vue
+++ b/src/components/SearchPage/Popup.vue
@@ -201,6 +201,10 @@ const options = computed(() => ({
     icon: 'fa-video-slash',
     data: v.prov.audio?.length,
   },
+  danmaku: {
+    icon: 'fa-subtitles',
+    data: v.prov.danmaku?.length,
+  },
 }));
 
 defineExpose({ getSelect });
@@ -284,6 +288,7 @@ async function getSelect(item: Types.MediaItem, select?: Types.PopupSelect) {
         video: false,
         audio: false,
         audioVideo: true,
+        danmaku: false,
       },
     });
   }
@@ -343,6 +348,16 @@ function click(key: keyof typeof extras.value | 'media', id: string) {
   }
   if (key === 'misc' && id === 'subtitles') {
     return (v.select.misc[id] = v.select.misc[id] ? false : v.subtitle);
+  }
+  if (key === 'media' && id === 'danmaku') {
+    v.select.media.danmaku = !v.select.media.danmaku;
+    if (v.select.media.danmaku) {
+      const hasSelection = v.select.danmaku.live || v.select.danmaku.history;
+      if (!hasSelection && v.prov.danmaku.includes('live')) {
+        v.select.danmaku.live = true;
+      }
+    }
+    return;
   }
   const k = v.select[key] as Record<string, boolean>;
   k[id] = !k[id];

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -79,7 +79,8 @@
     "mediaType": {
       "video": "Video",
       "audio": "Audio",
-      "audioVideo": "Video & Audio"
+      "audioVideo": "Video & Audio",
+      "danmaku": "Danmaku"
     }
   },
   "format": {

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -79,7 +79,8 @@
     "mediaType": {
       "video": "视频",
       "audio": "音频",
-      "audioVideo": "音视频"
+      "audioVideo": "音视频",
+      "danmaku": "弹幕"
     }
   },
   "format": {

--- a/src/services/queue.ts
+++ b/src/services/queue.ts
@@ -432,7 +432,12 @@ export function selectToSubTasks(id: string, select: Types.PopupSelect) {
   if (select.media.audio || select.media.audioVideo) push(Types.TaskType.Audio);
   if (select.media.audioVideo) push(Types.TaskType.AudioVideo);
   if (select.thumb.length) push(Types.TaskType.Thumb);
-  if (select.danmaku.live) push(Types.TaskType.LiveDanmaku);
+  if (
+    select.danmaku.live ||
+    (select.media.danmaku && !select.danmaku.history)
+  ) {
+    push(Types.TaskType.LiveDanmaku);
+  }
   if (select.danmaku.history) push(Types.TaskType.HistoryDanmaku);
   if (select.nfo.album) push(Types.TaskType.AlbumNfo);
   if (select.nfo.single) push(Types.TaskType.SingleNfo);

--- a/src/types/shared.d.ts
+++ b/src/types/shared.d.ts
@@ -56,6 +56,7 @@ export interface PopupSelect {
     video: boolean;
     audio: boolean;
     audioVideo: boolean;
+    danmaku?: boolean;
   };
 }
 


### PR DESCRIPTION
在“常规下载” (General Download) 界面中增加了“弹幕” (Danmaku) 选项，允许用户在常规下载模式下显式选择下载弹幕文件。

 **改动内容**
   1. UI: 在常规下载弹窗 (Popup.vue) 的主要选项中添加了“弹幕”按钮。
   2. 交互: 当选中“弹幕”时，若未指定具体类型（实时/历史），默认选中“实时弹幕”并高亮显示。
   3. 逻辑: 更新了 queue.ts 以处理新的弹幕下载参数。
   4. 类型: 更新了 shared.d.ts 类型定义。
   5. 多语言: 添加了 zh-CN 和 en-US 的对应翻译。
 **截图**
<img width="1920" height="1056" alt="image" src="https://github.com/user-attachments/assets/c35dd7ec-3318-42fa-87fc-663651c6f6a8" />
