### PR TITLE
fix: Fix double web pages opening on avatar click

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,6 @@
 - [aria2](https://github.com/aria2/aria2) aria2 is a lightweight multi-protocol & multi-source, cross platform download utility.
 - [FFmpeg](https://git.ffmpeg.org/ffmpeg.git) FFmpeg is a collection of libraries and tools to process multimedia content.
 - [DanmakuFactory](https://github.com/hihkm/DanmakuFactory) 支持特殊弹幕的xml转ass格式转换工具
-- [bilibili-API-collect](https://github.com/SocialSisterYi/bilibili-API-collect) 哔哩哔哩-API收集整理
 
 - [Vercel](https://github.com/vercel/vercel) Develop. Preview. Ship.
 

--- a/src/components/SearchPage/MediaInfo.vue
+++ b/src/components/SearchPage/MediaInfo.vue
@@ -27,6 +27,7 @@
             :src="props.info.nfo.upper.avatar"
             :height="36"
             class="rounded-full!"
+            prevent
           />
           <span class="text-xs truncate mt-1 w-20 text-center">{{
             info.nfo.upper?.name


### PR DESCRIPTION
点击头像时同时触发Image自身和外层<a>的 openUrl，导致即打开头像网页又打开up主主页
点击头像打开主页 是B站的通用交互逻辑
对 Image 组件新增prevent属性来解决